### PR TITLE
Fixed launch year filter bug

### DIFF
--- a/frontend-vue/src/components/FilterBar.vue
+++ b/frontend-vue/src/components/FilterBar.vue
@@ -67,8 +67,9 @@ updateLaunchYearFilter()
           :max="MOST_RECENT_LAUNCH_YEAR"
           :min-range="1"
           :enable-cross="false"
+          :lazy="true"
           id="launch-year-slider"
-          v-on:change="updateLaunchYearFilter"/>
+          v-on:drag-end="updateLaunchYearFilter"/>
           
         <input type="checkbox" id="include_without_launch_year" v-model="include_sats_without_launch_year" hidden>
         <label for="include_without_launch_year" hidden>Include satellites without launch year</label>


### PR DESCRIPTION
* Fixed the behaviour of satellites sometimes not loading per their launch year by making the slider "lazy" and switching from using an 'change' event to 'drag-end'.