### PR TITLE
Autodetect users' language preference from browser settings

### DIFF
--- a/frontend-vue/src/main.ts
+++ b/frontend-vue/src/main.ts
@@ -8,10 +8,14 @@ import * as Sentry from "@sentry/vue";
 
 import { createI18n } from 'vue-i18n'
 
+// Get the language currently preferred by the 
+// browser, or use English if it is not available
+const browserLocale = navigator.language || 'en'
+
 const i18n = createI18n({
     legacy: false,
-    locale: "en",
-    fallbackLocale: "nl"
+    locale: browserLocale,
+    fallbackLocale: "en"
 })
 
 const app = createApp(App)


### PR DESCRIPTION
* The `navigator.language` property is now used to determine the users' preferred language. If it is not defined, English is used.

Can be tested by changing preferred web content language in the browser.